### PR TITLE
Fetch custom engine with 'engine' subcommand

### DIFF
--- a/hookit/hooks/configure.rb
+++ b/hookit/hooks/configure.rb
@@ -91,8 +91,7 @@ if boxfile[:engine] and not is_filepath?(boxfile[:engine])
 
   execute "fetching #{engine}" do
     command <<-EOF
-      nanobox \
-        fetch \
+      nanobox engine fetch \
         #{boxfile[:engine]} \
           | tar \
             -xzf - \


### PR DESCRIPTION
Recently, the nanobox cli has been refactored to move the 'fetch' subcommand
into it's own subcollection. All engine-related commands have now been
isolated under the 'engine' subcommand. Fetching a custom engine is now done
via 'nanobox engine fetch' instead of 'nanobox fetch'.
