### PR TITLE
Change code_dir and live_dir locations to work with dev container

### DIFF
--- a/hookit/lib/engine.rb
+++ b/hookit/lib/engine.rb
@@ -7,14 +7,14 @@ module NanoBox
     SHARE_DIR       = '/share'
     MNT_DIR         = '/mnt'
     BUILD_DIR       = '/data'
-    LIVE_DIR        = '/code'
+    LIVE_DIR        = '/live'
     CODE_DIR        = "#{MNT_DIR}/build"
     DEPLOY_DIR      = "#{MNT_DIR}/deploy"
     CACHE_DIR       = "#{MNT_DIR}/cache"
     APP_CACHE_DIR   = "#{CACHE_DIR}/app"
     LIB_CACHE_DIR   = "#{CACHE_DIR}/lib_dirs"
     ENGINE_DIR      = '/opt/engines'
-    CODE_STAGE_DIR  = '/opt/code'
+    CODE_STAGE_DIR  = '/code'
     CODE_LIVE_DIR   = "#{SHARE_DIR}/code"
     ENGINE_LIVE_DIR = "#{SHARE_DIR}/engines"
     ETC_DIR         = "#{BUILD_DIR}/etc"


### PR DESCRIPTION
Currently  the code_dir is set to /opt/code and the live_dir is set to /code.
Problems arise when virtual environments like python's pip or bin stubs
are needed to be created within the code_dir during the build process.
Scripts that are generated will be shebanged to /opt/code instead of code,
which when placed in the dev container, will actually exist at /code and
will thus break.

All of the hooks already reference the constants, so this change should
be trivial and without consequence.
