### PR TITLE
Make packages, prepare, before, & after standard

### DIFF
--- a/hookit/hooks/build.rb
+++ b/hookit/hooks/build.rb
@@ -2,6 +2,26 @@
 include NanoBox::Engine
 include NanoBox::Output
 
+# before
+logtap.print(bullet("Running before hook..."), 'debug')
+
+if not boxfile[:before]
+  exit 0
+end
+
+logtap.print(bullet("'Before' detected, running now..."), 'debug')
+
+execute "before code" do
+  command boxfile[:before]
+  cwd "#{CODE_DIR}"
+  path GONANO_PATH
+  user 'gonano'
+  stream true
+  on_data {|data| logtap.print data}
+end
+
+
+# build
 logtap.print(bullet("Running build hook..."), 'debug')
 
 # By this point, engine should be set in the registry
@@ -17,6 +37,25 @@ logtap.print(bullet("Build script detected, running now..."), 'debug')
 execute "build code" do
   command %Q(#{ENGINE_DIR}/#{engine}/bin/build '#{engine_payload}')
   cwd "#{ENGINE_DIR}/#{engine}/bin"
+  path GONANO_PATH
+  user 'gonano'
+  stream true
+  on_data {|data| logtap.print data}
+end
+
+
+# after
+logtap.print(bullet("Running after hook..."), 'debug')
+
+if not boxfile[:after]
+  exit 0
+end
+
+logtap.print(bullet("'After' detected, running now..."), 'debug')
+
+execute "after code" do
+  command boxfile[:after]
+  cwd "#{CODE_DIR}"
   path GONANO_PATH
   user 'gonano'
   stream true

--- a/hookit/hooks/prepare.rb
+++ b/hookit/hooks/prepare.rb
@@ -2,6 +2,23 @@
 include NanoBox::Engine
 include NanoBox::Output
 
+# user prepare
+logtap.print(bullet("Running user prepare hook..."), 'debug')
+
+if boxfile[:prepare]
+  logtap.print(bullet("'prepare' detected, running now..."), 'debug')
+
+  execute "prepare code" do
+    command boxfile[:prepare]
+    cwd "#{CODE_DIR}"
+    path GONANO_PATH
+    user 'gonano'
+    stream true
+    on_data {|data| logtap.print data}
+  end
+end
+
+
 logtap.print(bullet("Running prepare hook..."), 'debug')
 
 # By this point, engine should be set in the registry

--- a/hookit/hooks/prepare.rb
+++ b/hookit/hooks/prepare.rb
@@ -2,11 +2,23 @@
 include NanoBox::Engine
 include NanoBox::Output
 
+# user-defined packages
+if boxfile[:packages]
+  logtap.print(bullet("Packages declared, installing now..."), 'debug')
+
+  execute "install packages" do
+    command "pkgin -y in #{[boxfile[:packages]].join(' ')}"
+    path GONANO_PATH
+    stream true
+    on_data {|data| logtap.print(data, 'debug')}
+  end
+end
+
 # user prepare
 logtap.print(bullet("Running user prepare hook..."), 'debug')
 
 if boxfile[:prepare]
-  logtap.print(bullet("'prepare' detected, running now..."), 'debug')
+  logtap.print(bullet("'Prepare' detected, running now..."), 'debug')
 
   execute "prepare code" do
     command boxfile[:prepare]


### PR DESCRIPTION
By moving these 'hooks' to hookit, it alleviates the stress on engine developers to support them, and gives users a standard customization offering across all engines.
