### PR TITLE
Make packages, prepare, before, & after standard

### DIFF
--- a/hookit/hooks/build.rb
+++ b/hookit/hooks/build.rb
@@ -5,7 +5,7 @@ include NanoBox::Output
 # before
 logtap.print(bullet("Running before hook..."), 'debug')
 
-if not boxfile[:before]
+if boxfile[:before]
   logtap.print(bullet("'Before' detected, running now..."), 'debug')
 
   execute "before code" do

--- a/hookit/hooks/build.rb
+++ b/hookit/hooks/build.rb
@@ -13,7 +13,7 @@ if boxfile[:before]
   end
 
   boxfile[:before].each_with_index do |before_hook, i|
-    logtap.print subtask_start "Before hook #{i}"
+    logtap.print subtask_start "Running before hook #{i}"
     logtap.print bullet_info "$ #{before_hook}"
 
     execute "before code" do
@@ -64,7 +64,7 @@ if boxfile[:after]
   end
 
   boxfile[:after].each_with_index do |after_hook, i|
-    logtap.print subtask_start "After hook #{i}"
+    logtap.print subtask_start "Running after hook #{i}"
     logtap.print bullet_info "$ #{after_hook}"
 
     execute "after code" do

--- a/hookit/hooks/build.rb
+++ b/hookit/hooks/build.rb
@@ -2,6 +2,26 @@
 include NanoBox::Engine
 include NanoBox::Output
 
+# before
+logtap.print(bullet("Running before hook..."), 'debug')
+
+if not boxfile[:before]
+  exit 0
+end
+
+logtap.print(bullet("'Before' detected, running now..."), 'debug')
+
+execute "before code" do
+  command boxfile[:before]
+  cwd "#{CODE_DIR}"
+  path GONANO_PATH
+  user 'gonano'
+  stream true
+  on_data {|data| logtap.print data}
+end
+
+
+# build
 logtap.print(bullet("Running build hook..."), 'debug')
 
 # By this point, engine should be set in the registry
@@ -17,6 +37,25 @@ logtap.print(bullet("Build script detected, running now..."), 'debug')
 execute "build code" do
   command %Q(#{ENGINE_DIR}/#{engine}/bin/build '#{engine_payload}')
   cwd "#{ENGINE_DIR}/#{engine}/bin"
+  path GONANO_PATH
+  user 'gonano'
+  stream true
+  on_data {|data| logtap.print data}
+end
+
+
+# after
+logtap.print(bullet("Running after hook..."), 'debug')
+
+if not boxfile[:after]
+  exit 0
+end
+
+logtap.print(bullet("'After' detected, running now..."), 'debug')
+
+execute "after code" do
+  command boxfile[:after]
+  cwd "#{CODE_DIR}"
   path GONANO_PATH
   user 'gonano'
   stream true

--- a/hookit/hooks/build.rb
+++ b/hookit/hooks/build.rb
@@ -3,18 +3,31 @@ include NanoBox::Engine
 include NanoBox::Output
 
 # before
-logtap.print(bullet("Running before hook..."), 'debug')
+logtap.print (bullet("Running before hook..."), 'debug')
 
 if boxfile[:before]
-  logtap.print(bullet("'Before' detected, running now..."), 'debug')
+  logtap.print (bullet("'Before' detected, running now..."), 'debug')
 
-  execute "before code" do
-    command boxfile[:before]
-    cwd "#{CODE_DIR}"
-    path GONANO_PATH
-    user 'gonano'
-    stream true
-    on_data {|data| logtap.print data}
+  logtap.print 'what is before'
+  if boxfile[:before].is_a?(String)
+    logtap.print 'before is a string'
+    boxfile[:before]=[boxfile[:before]]
+  end
+
+  boxfile[:before].each_with_index do |before_hook, i|
+    logtap.print subtask_start "Before hook #{i}"
+    logtap.print bullet_info "$ #{before_hook}"
+
+    execute "before code" do
+      command before_hook
+      cwd "#{CODE_DIR}"
+      path GONANO_PATH
+      user 'gonano'
+      stream true
+      on_data {|data| logtap.print data}
+      on_exit { |code| logtap.print code == 0 ? subtask_success : subtask_fail }
+    end
+
   end
 end
 
@@ -43,17 +56,28 @@ end
 
 
 # after
-logtap.print(bullet("Running after hook..."), 'debug')
+logtap.print (bullet("Running after hook..."), 'debug')
 
 if boxfile[:after]
-  logtap.print(bullet("'After' detected, running now..."), 'debug')
+  logtap.print (bullet("'After' detected, running now..."), 'debug')
 
-  execute "after code" do
-    command boxfile[:after]
-    cwd "#{CODE_DIR}"
-    path GONANO_PATH
-    user 'gonano'
-    stream true
-    on_data {|data| logtap.print data}
+  if boxfile[:after].is_a?(String)
+    boxfile[:after]=[boxfile[:after]]
+  end
+
+  boxfile[:after].each_with_index do |after_hook, i|
+    logtap.print subtask_start "After hook #{i}"
+    logtap.print bullet_info "$ #{after_hook}"
+
+    execute "after code" do
+      command after_hook
+      cwd "#{CODE_DIR}"
+      path GONANO_PATH
+      user 'gonano'
+      stream true
+      on_data {|data| logtap.print data}
+      on_exit { |code| logtap.print code == 0 ? subtask_success : subtask_fail }
+    end
+
   end
 end

--- a/hookit/hooks/build.rb
+++ b/hookit/hooks/build.rb
@@ -6,18 +6,16 @@ include NanoBox::Output
 logtap.print(bullet("Running before hook..."), 'debug')
 
 if not boxfile[:before]
-  exit 0
-end
+  logtap.print(bullet("'Before' detected, running now..."), 'debug')
 
-logtap.print(bullet("'Before' detected, running now..."), 'debug')
-
-execute "before code" do
-  command boxfile[:before]
-  cwd "#{CODE_DIR}"
-  path GONANO_PATH
-  user 'gonano'
-  stream true
-  on_data {|data| logtap.print data}
+  execute "before code" do
+    command boxfile[:before]
+    cwd "#{CODE_DIR}"
+    path GONANO_PATH
+    user 'gonano'
+    stream true
+    on_data {|data| logtap.print data}
+  end
 end
 
 
@@ -47,17 +45,15 @@ end
 # after
 logtap.print(bullet("Running after hook..."), 'debug')
 
-if not boxfile[:after]
-  exit 0
-end
+if boxfile[:after]
+  logtap.print(bullet("'After' detected, running now..."), 'debug')
 
-logtap.print(bullet("'After' detected, running now..."), 'debug')
-
-execute "after code" do
-  command boxfile[:after]
-  cwd "#{CODE_DIR}"
-  path GONANO_PATH
-  user 'gonano'
-  stream true
-  on_data {|data| logtap.print data}
+  execute "after code" do
+    command boxfile[:after]
+    cwd "#{CODE_DIR}"
+    path GONANO_PATH
+    user 'gonano'
+    stream true
+    on_data {|data| logtap.print data}
+  end
 end

--- a/hookit/hooks/build.rb
+++ b/hookit/hooks/build.rb
@@ -8,9 +8,7 @@ logtap.print (bullet("Running before hook..."), 'debug')
 if boxfile[:before]
   logtap.print (bullet("'Before' detected, running now..."), 'debug')
 
-  logtap.print 'what is before'
   if boxfile[:before].is_a?(String)
-    logtap.print 'before is a string'
     boxfile[:before]=[boxfile[:before]]
   end
 

--- a/hookit/hooks/prepare.rb
+++ b/hookit/hooks/prepare.rb
@@ -2,6 +2,23 @@
 include NanoBox::Engine
 include NanoBox::Output
 
+# user prepare
+logtap.print(bullet("Running user prepare hook..."), 'debug')
+
+if boxfile[:prepare]
+  logtap.print(bullet("'prepare' detected, running now..."), 'debug')
+
+  execute "prepare code" do
+    command boxfile[:prepare]
+    cwd "#{CODE_DIR}"
+    path GONANO_PATH
+    user 'gonano'
+    stream true
+    on_data {|data| logtap.print data}
+  end
+end
+
+
 logtap.print(bullet("Running prepare hook..."), 'debug')
 
 # By this point, engine should be set in the registry

--- a/hookit/hooks/prepare.rb
+++ b/hookit/hooks/prepare.rb
@@ -6,11 +6,15 @@ include NanoBox::Output
 if boxfile[:packages]
   logtap.print(bullet("Packages declared, installing now..."), 'debug')
 
+  logtap.print subtask_start "Package install"
+  logtap.print bullet_info "$ pkgin -y in #{[boxfile[:packages]].join(' ')}"
+
   execute "install packages" do
     command "pkgin -y in #{[boxfile[:packages]].join(' ')}"
     path GONANO_PATH
     stream true
-    on_data {|data| logtap.print(data, 'debug')}
+    on_data { |data| logtap.print(data, 'debug') }
+    on_exit { |code| logtap.print code == 0 ? subtask_success : subtask_fail }
   end
 end
 

--- a/hookit/hooks/prepare.rb
+++ b/hookit/hooks/prepare.rb
@@ -15,21 +15,32 @@ if boxfile[:packages]
 end
 
 # user prepare
-logtap.print(bullet("Running user prepare hook..."), 'debug')
+logtap.print (bullet("Running user prepare hook..."), 'debug')
 
 if boxfile[:prepare]
-  logtap.print(bullet("'Prepare' detected, running now..."), 'debug')
+  logtap.print (bullet("'Prepare' detected, running now..."), 'debug')
 
-  execute "prepare code" do
-    command boxfile[:prepare]
-    cwd "#{CODE_DIR}"
-    path GONANO_PATH
-    user 'gonano'
-    stream true
-    on_data {|data| logtap.print data}
+  if boxfile[:prepare].is_a?(String)
+    boxfile[:prepare]=[boxfile[:prepare]]
+  end
+
+  boxfile[:prepare].each_with_index do |prepare_hook, i|
+
+    logtap.print subtask_start "Prepare hook #{i}"
+    logtap.print bullet_info "$ #{prepare_hook}"
+
+    execute "prepare code" do
+      command prepare_hook
+      cwd "#{CODE_DIR}"
+      path GONANO_PATH
+      user 'gonano'
+      stream true
+      on_data {|data| logtap.print data}
+      on_exit { |code| logtap.print code == 0 ? subtask_success : subtask_fail }
+    end
+
   end
 end
-
 
 logtap.print(bullet("Running prepare hook..."), 'debug')
 

--- a/hookit/hooks/prepare.rb
+++ b/hookit/hooks/prepare.rb
@@ -2,11 +2,23 @@
 include NanoBox::Engine
 include NanoBox::Output
 
+# user-defined packages
+if boxfile[:packages]
+  logtap.print(bullet("Packages declared, installing now..."), 'debug')
+
+  execute "install packages" do
+    command "pkgin -y in #{[boxfile[:packages]].join(' ')}"
+    path GONANO_PATH
+    stream true
+    on_data {|data| logtap.print(data, 'debug')}
+  end
+end
+
 # user prepare
 logtap.print(bullet("Running user prepare hook..."), 'debug')
 
 if boxfile[:prepare]
-  logtap.print(bullet("'prepare' detected, running now..."), 'debug')
+  logtap.print(bullet("'Prepare' detected, running now..."), 'debug')
 
   execute "prepare code" do
     command boxfile[:prepare]

--- a/hookit/hooks/prepare.rb
+++ b/hookit/hooks/prepare.rb
@@ -6,7 +6,7 @@ include NanoBox::Output
 if boxfile[:packages]
   logtap.print(bullet("Packages declared, installing now..."), 'debug')
 
-  logtap.print subtask_start "Package install"
+  logtap.print subtask_start "Installing custom packages"
   logtap.print bullet_info "$ pkgin -y in #{[boxfile[:packages]].join(' ')}"
 
   execute "install packages" do
@@ -30,7 +30,7 @@ if boxfile[:prepare]
 
   boxfile[:prepare].each_with_index do |prepare_hook, i|
 
-    logtap.print subtask_start "Prepare hook #{i}"
+    logtap.print subtask_start "Running prepare hook #{i}"
     logtap.print bullet_info "$ #{prepare_hook}"
 
     execute "prepare code" do


### PR DESCRIPTION
By moving these 'hooks' to hookit, it alleviates the stress on engine developers to support them, and gives users a standard customization offering across all engines.
